### PR TITLE
removing dead code/unused constant

### DIFF
--- a/car/inc/board_link.h
+++ b/car/inc/board_link.h
@@ -25,7 +25,6 @@
 #define ACK_MAGIC 0x54
 #define PAIR_MAGIC 0x55
 #define UNLOCK_MAGIC 0x56
-#define ENABLE_MAGIC 0x57
 #define START_MAGIC 0x57
 #define BOARD_UART ((uint32_t)UART1_BASE)
 

--- a/fob/inc/board_link.h
+++ b/fob/inc/board_link.h
@@ -25,7 +25,6 @@
 #define ACK_MAGIC 0x54
 #define PAIR_MAGIC 0x55
 #define UNLOCK_MAGIC 0x56
-#define ENABLE_MAGIC 0x57
 #define START_MAGIC 0x57
 #define BOARD_UART ((uint32_t)UART1_BASE)
 


### PR DESCRIPTION
ENABLE_MAGIC is unused in the car/fob source, and can be omitted.