### PR TITLE
Fixed param labeling to match header file/uart.c conventions

### DIFF
--- a/car/src/uart.c
+++ b/car/src/uart.c
@@ -67,7 +67,7 @@ void uart_init(void) {
  * @return true if there is data available.
  * @return false if there is no data available.
  */
-bool uart_avail(uint32_t interface) { return UARTCharsAvail(interface); }
+bool uart_avail(uint32_t uart) { return UARTCharsAvail(uart); }
 
 /**
  * @brief Read a byte from a UART interface.

--- a/fob/src/uart.c
+++ b/fob/src/uart.c
@@ -67,7 +67,7 @@ void uart_init(void) {
  * @return true if there is data available.
  * @return false if there is no data available.
  */
-bool uart_avail(uint32_t interface) { return UARTCharsAvail(interface); }
+bool uart_avail(uint32_t uart) { return UARTCharsAvail(uart); }
 
 /**
  * @brief Read a byte from a UART interface.


### PR DESCRIPTION
In the uart.c files of the car and fob directories, the 'uart_avail' function uses variable 'interface' instead of variable 'uart'. This mismatches with the name of the variable in uart.h, the doxygen documentation, and with the rest of the convention of the uart.c files.