### PR TITLE
Fixed bug in package_tool

### DIFF
--- a/host_tools/package_tool
+++ b/host_tools/package_tool
@@ -28,7 +28,7 @@ def package(package_name, car_id, feature_number):
     # Create package to match defined structure on fob
     package_message_bytes = (
         str.encode(car_id + car_id_pad)
-        + feature_number.to_bytes(1, "little")
+        + (feature_number & 0xff).to_bytes(1, "little")
         + str.encode("\n")
     )
 


### PR DESCRIPTION
`package_tool` takes a feature_number and tries to convert it to 1 byte with `feature_number.to_bytes(1, "little")` which will break for any feature numbers greater than 255 with the error `OverflowError: int too big to convert`. The technical specification says the feature number is 32 bits long.

To make it conform to the technical specifications but with minimal refactoring (the package number is expected to be 1 byte in several places), and since the only feature numbers that will be used are 1 and 2, the feature number is truncated to 8 bits during packaging