### PR TITLE
Fix bug with the incorrect interpretation of feature numbers 0, 10 and 13

### DIFF
--- a/fob/src/firmware.c
+++ b/fob/src/firmware.c
@@ -276,7 +276,7 @@ void enableFeature(FLASH_DATA *fob_state_ram)
 {
   if (fob_state_ram->paired == FLASH_PAIRED)
   {
-    uint8_t uart_buffer[20];
+    uint8_t uart_buffer[24];
     uart_readline(HOST_UART, uart_buffer);
 
     ENABLE_PACKET *enable_message = (ENABLE_PACKET *)uart_buffer;
@@ -285,6 +285,8 @@ void enableFeature(FLASH_DATA *fob_state_ram)
     {
       return;
     }
+
+    enable_message->feature = (uint8_t)atoi((char *)uart_buffer + 8);
 
     // Feature list full
     if (fob_state_ram->feature_info.num_active == NUM_FEATURES)

--- a/host_tools/package_tool
+++ b/host_tools/package_tool
@@ -28,7 +28,8 @@ def package(package_name, car_id, feature_number):
     # Create package to match defined structure on fob
     package_message_bytes = (
         str.encode(car_id + car_id_pad)
-        + feature_number.to_bytes(1, "little")
+        # encode feature number as string and pad to 3 bytes
+        + str.encode(str(feature_number).zfill(3))
         + str.encode("\n")
     )
 


### PR DESCRIPTION
Features 0, 10 and 13 were treated as duplicates due to incorrect parsing of the buffer data.
Pack feature numbers to avoid truncation with uart functions.